### PR TITLE
fix(marker): `markSimpleObject` add null check

### DIFF
--- a/src/utils/marker.ts
+++ b/src/utils/marker.ts
@@ -6,6 +6,7 @@ const constructorString = Object.prototype.constructor.toString();
  * support case: https://github.com/unadlib/mutative/issues/17
  */
 const isSimpleObject = (value: unknown) => {
+  if (!value || typeof value !== 'object') return false;
   const prototype = Object.getPrototypeOf(value);
   if (prototype === null) {
     return true;
@@ -13,6 +14,9 @@ const isSimpleObject = (value: unknown) => {
   const constructor =
     Object.hasOwnProperty.call(prototype, 'constructor') &&
     prototype.constructor;
+
+  if (constructor === Object) return true;
+
   return (
     typeof constructor === 'function' &&
     Function.toString.call(constructor) === constructorString


### PR DESCRIPTION
Currently:

```js
const { create, markSimpleObject, rawReturn } = require('mutative');

create(null, (_draft) => rawReturn({}), {
  mark: markSimpleObject,
});
```

will throw error:

```
TypeError: Cannot convert undefined or null to object
```

Reproduction: https://stackblitz.com/edit/stackblitz-starters-k3gwyj?file=index.js

Reference: https://github.com/unadlib/mutative/blob/ed780e0dc0e3ff864fbb9c7d0af3439ccf4100cc/test/immer/src/immer.ts#L164-L181