### PR TITLE
fix(copy): align behavior of shallow copy with object spread

### DIFF
--- a/src/utils/copy.ts
+++ b/src/utils/copy.ts
@@ -22,6 +22,8 @@ function strictCopy(target: any) {
   return Object.create(Object.getPrototypeOf(target), descriptors);
 }
 
+const propIsEnum = Object.prototype.propertyIsEnumerable;
+
 export function shallowCopy(original: any, options?: Options<any, any>) {
   let markResult: any;
   if (Array.isArray(original)) {
@@ -55,7 +57,12 @@ export function shallowCopy(original: any, options?: Options<any, any>) {
     // don't use `Object.create(Object.getPrototypeOf(obj), Object.getOwnPropertyDescriptors(obj));` by default.
     const copy: Record<string | symbol, any> = {};
     Object.keys(original).forEach((key) => {
-      copy![key] = original[key];
+      copy[key] = original[key];
+    });
+    Object.getOwnPropertySymbols(original).forEach((key) => {
+      if (propIsEnum.call(original, key)) {
+        copy[key] = original[key];
+      }
     });
     return copy;
   } else {

--- a/test/immer/__tests__/base.ts
+++ b/test/immer/__tests__/base.ts
@@ -909,13 +909,11 @@ function runBaseTest(name, autoFreeze, useStrictShallowCopy, useListener) {
       const test = Symbol('test');
       const baseState = { [test]: true };
       const nextState = produce(baseState, (s) => {
-        // !!! This is different from immer
-        // expect(s[test]).toBeTruthy();
+        expect(s[test]).toBeTruthy();
         s.foo = true;
       });
-      // !!! This is different from immer
       expect(nextState).toEqual({
-        // [test]: true,
+        [test]: true,
         foo: true,
       });
     });


### PR DESCRIPTION
Follow up on https://github.com/unadlib/mutative/issues/25

In real-world use, there won't be tons of symbol keys in an object, so any slowdown in performance shouldn't be a big deal.

Also, I think we might need some more test cases for this one.

---

Reference: how `esbuild` transforms spread syntax:

```js
var __defProp = Object.defineProperty;
var __getOwnPropSymbols = Object.getOwnPropertySymbols;
var __hasOwnProp = Object.prototype.hasOwnProperty;
var __propIsEnum = Object.prototype.propertyIsEnumerable;
var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
var __spreadValues = (a, b) => {
  for (var prop in b || (b = {}))
    if (__hasOwnProp.call(b, prop))
      __defNormalProp(a, prop, b[prop]);
  if (__getOwnPropSymbols)
    for (var prop of __getOwnPropSymbols(b)) {
      if (__propIsEnum.call(b, prop))
        __defNormalProp(a, prop, b[prop]);
    }
  return a;
};
const state = { count: 1 };
const newState = __spreadValues({}, state);
```

<https://hyrious.me/esbuild-repl/?version=0.19.10&t=const+state+%3D+%7B+count%3A+1+%7D%3B%0Aconst+newState+%3D+%7B+...state+%7D%3B&o=--target%3Des6>