### PR TITLE
test(test): fix inconsistent timezone in date tests

### DIFF
--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -1060,7 +1060,7 @@ describe('hook in options', () => {
     const state = create(
       data,
       (draft) => {
-        draft.date.setFullYear(2000);
+        draft.date.setMilliseconds(42);
       },
       {
         mark: (target) => {
@@ -1071,8 +1071,8 @@ describe('hook in options', () => {
     expect(data).not.toBe(state);
     expect(data.foo).toBe(state.foo);
     expect(data.date).not.toBe(state.date);
-    expect(state.date.getTime()).toBe(946684800000);
-    expect(data.date.getTime()).not.toBe(946684800000);
+    expect(state.date.getTime()).toBe(42);
+    expect(data.date.getTime()).not.toBe(42);
   });
 
   class A {}

--- a/test/unsafe.test.ts
+++ b/test/unsafe.test.ts
@@ -537,7 +537,7 @@ test('change Date instance - custom shallow copy', () => {
   const state = create(
     data,
     (draft) => {
-      draft.date.setFullYear(2000);
+      draft.date.setMilliseconds(42);
     },
     {
       strict: true,
@@ -549,8 +549,8 @@ test('change Date instance - custom shallow copy', () => {
   expect(data).not.toBe(state);
   expect(data.foo).toBe(state.foo);
   expect(data.date).not.toBe(state.date);
-  expect(state.date.getTime()).toBe(946684800000);
-  expect(data.date.getTime()).not.toBe(946684800000);
+  expect(state.date.getTime()).toBe(42);
+  expect(data.date.getTime()).not.toBe(42);
 });
 
 test('change Date instance', () => {
@@ -565,7 +565,7 @@ test('change Date instance', () => {
     data,
     (draft) => {
       unsafe(() => {
-        draft.date.setFullYear(2000);
+        draft.date.setMilliseconds(42);
       });
     },
     {
@@ -575,5 +575,5 @@ test('change Date instance', () => {
   expect(data).toBe(state);
   expect(data.foo).toBe(state.foo);
   expect(data.date).toBe(state.date);
-  expect(state.date.getTime()).toBe(946684800000);
+  expect(state.date.getTime()).toBe(42);
 });


### PR DESCRIPTION
I noticed a few date-related tests weren't passing for me locally:

```
 FAIL  test/unsafe.test.ts
  ● change Date instance

    expect(received).toBe(expected) // Object.is equality

    Expected: 946684800000
    Received: 946627200000

      577 |   expect(data.foo).toBe(state.foo);
      578 |   expect(data.date).toBe(state.date);
    > 579 |   expect(state.date.getTime()).toBe(946684800000);
          |                                ^
      580 | });
      581 |

      at Object.<anonymous> (test/unsafe.test.ts:579:32)
```

I believe this is because `setFullYear` applies the system's local time zone automatically. Using `setMilliseconds` should avoid this issue. With this change, all tests pass locally and presumably shouldn't impact the github actions test runner.

I love the library and I'm excited to start poking around the code more!