### PR TITLE
fix: avoid deep copying unnecessarily in current

### DIFF
--- a/test/immer/__tests__/current.ts
+++ b/test/immer/__tests__/current.ts
@@ -253,5 +253,15 @@ function runTests(name) {
         expect(c).toBeInstanceOf(Counter);
       });
     });
+
+    it("won't deep copy unchanged values unnecessarily", () => {
+      const obj = { k: 42 };
+      const base = { x: { y: { z: obj } } };
+      produce(base, (draft) => {
+        draft.x = { y: { z: obj } };
+        const c = current(draft);
+        expect(c.x.y.z).toBe(obj);
+      });
+    });
   });
 }


### PR DESCRIPTION
Fix for https://github.com/unadlib/mutative/issues/47

Avoids creating a copy of all the nested objects when invoking current by lazily computing the copy of non-draft objects, only if necessary.

Performance seems to be still worse than just `create` (aka `finalize`), but at least it avoids creating new objects when unnecessary.