### PR TITLE
perf(cache): improve drafts cache for perf

### DIFF
--- a/src/draftify.ts
+++ b/src/draftify.ts
@@ -21,6 +21,7 @@ export function draftify<
     draft: [],
     revoke: [],
     handledSet: new WeakSet<any>(),
+    draftsCache: new WeakSet<object>(),
   };
   let patches: Patches | undefined;
   let inversePatches: Patches | undefined;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -32,6 +32,7 @@ export interface Finalities {
   draft: ((patches?: Patches, inversePatches?: Patches) => void)[];
   revoke: (() => void)[];
   handledSet: WeakSet<any>;
+  draftsCache: WeakSet<object>;
 }
 
 export interface ProxyDraft<T = any> {


### PR DESCRIPTION
This PR primarily refactors the draft cache by changing the original global draft cache into a built-in cache option. This helps to separate unrelated WeakSet caches, thereby improving performance.

Before:

```
----------------------------------------------- -------------------------------
update: vanilla (freeze: false)   55.98 µs/iter  80.17 µs █
                         (42.71 µs … 393.08 µs)  89.50 µs █               ▂
                        ( 11.11 kb … 295.45 kb)  84.01 kb █▄▂▁▁▁▁▁▁▁▁▁▁▁▁▁█▂▂▁▁

update: immer10 (freeze: false)  445.57 µs/iter 443.38 µs   █
                        (436.04 µs … 851.83 µs) 487.33 µs   ██
                        ( 21.17 kb …   1.33 mb)  87.96 kb ▁▇██▄▂▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁

update: mutative (freeze: false)  12.45 µs/iter   4.29 µs  ▇█
                            (3.67 µs … 1.73 ms)   8.04 µs  ██▆
                        (  3.45 kb … 416.33 kb)  87.49 kb ▂███▅▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁

update: vanilla (freeze: true)    46.82 µs/iter  47.05 µs █ █       █
                          (46.28 µs … 47.32 µs)  47.31 µs █ █       █ ▅ ▅▅   ▅▅
                        (  1.31 kb …   1.31 kb)   1.31 kb █▁█▁▁▁▁▁▁▁█▁█▁██▁▁▁██

update: immer10 (freeze: true)   477.48 µs/iter 476.67 µs █▅▆
                        (472.92 µs … 836.71 µs) 514.42 µs ███
                        ( 83.83 kb …   1.09 mb)  86.20 kb ███▄▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

update: mutative (freeze: true)   12.06 µs/iter   4.21 µs  █
                            (3.67 µs … 1.68 ms)   7.71 µs  ██▃
                        (  1.02 kb … 384.77 kb)  85.20 kb ▂███▅▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

summary
  update: mutative (freeze: true)
   1.03x faster than update: mutative (freeze: false)
   3.88x faster than update: vanilla (freeze: true)
   4.64x faster than update: vanilla (freeze: false)
   36.94x faster than update: immer10 (freeze: false)
   39.59x faster than update: immer10 (freeze: true)
```

After:
```
----------------------------------------------- -------------------------------
update: vanilla (freeze: false)   53.47 µs/iter  78.17 µs █
                         (40.50 µs … 417.29 µs)  86.88 µs █
                        ( 14.61 kb … 285.95 kb)  84.00 kb █▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁█▂▂▁▁

update: immer10 (freeze: false)  432.56 µs/iter 432.38 µs  █
                        (423.54 µs … 797.04 µs) 483.00 µs  █▄
                        ( 80.33 kb …   1.05 mb)  88.21 kb ▄██▇▅▃▂▁▁▁▁▂▁▁▁▁▁▁▁▁▁

update: mutative (freeze: false)   3.87 µs/iter   3.87 µs     █  ▅
                            (3.83 µs … 3.97 µs)   3.96 µs  ▃█▃█▃▃█▃▃
                        (  1.34 kb …   2.64 kb)   2.56 kb ▄█████████▄▁▁▁▁▁▁▁▁▁█

update: vanilla (freeze: true)    42.82 µs/iter  43.16 µs    █  █             █
                          (42.33 µs … 43.33 µs)  43.28 µs ▅  █ ▅█    ▅▅    ▅  █
                        (  1.31 kb …   1.31 kb)   1.31 kb █▁▁█▁██▁▁▁▁██▁▁▁▁█▁▁█

update: immer10 (freeze: true)   468.23 µs/iter 467.33 µs  █
                        (460.88 µs … 780.83 µs) 512.21 µs  █▆
                        (  5.97 kb … 940.83 kb)  85.95 kb ▆██▆▄▂▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁

update: mutative (freeze: true)    3.73 µs/iter   3.74 µs   ▄▄█   ▄
                            (3.70 µs … 3.84 µs)   3.81 µs   ███▅ ██
                        (  1.31 kb …   3.61 kb)   1.39 kb █████████▅██▅▁▁▁▁▁▁▁▅

summary
  update: mutative (freeze: true)
   1.04x faster than update: mutative (freeze: false)
   11.47x faster than update: vanilla (freeze: true)
   14.33x faster than update: vanilla (freeze: false)
   115.9x faster than update: immer10 (freeze: false)
   125.45x faster than update: immer10 (freeze: true)
```

Overall, this results in a 2-3X performance improvement for Array operations.