### PR TITLE
fix(type): export DraftedObject

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,5 @@ export type {
   Patch,
   ExternalOptions as Options,
   PatchesOptions,
+  DraftedObject,
 } from './interface';

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -183,7 +183,7 @@ export type Immutable<T> = T extends Primitive | AtomicObject
 
 type DraftedMap<K, V> = Map<K, Draft<V>>;
 type DraftedSet<T> = Set<Draft<T>>;
-type DraftedObject<T> = {
+export type DraftedObject<T> = {
   -readonly [K in keyof T]: Draft<T[K]>;
 };
 


### PR DESCRIPTION
The use case is to create reusable, type-safe utility functions that operate specifically on a Mutative draft object. Currently, we cannot properly type the draft argument in these external utility functions because the `DraftedObject` type is not exported.