### PR TITLE
build(rollup): add build analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 .tern-port
 
 benchmark.csv
+
+# Analyzer output
+stats.html

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "performance:array-object": "cd test/performance && NODE_ENV='production' ts-node array-object.ts",
     "performance": "yarn build && yarn performance:immer && yarn performance:basic && yarn performance:set-map && yarn performance:big-object && yarn performance:sample && yarn performance:array-object",
     "build": "yarn clean && rollup --config --bundleConfigAsCjs",
+    "build:analyze": "yarn clean && ANALYZE=true rollup --config --bundleConfigAsCjs",
     "build:doc": "rimraf docs && typedoc --plugin typedoc-plugin-markdown --out docs src/index.ts --readme none",
     "commit": "yarn git-cz",
     "size": "size-limit",
@@ -130,6 +131,7 @@
     "typedoc": "^0.28.12",
     "typedoc-plugin-markdown": "^4.8.1",
     "typescript": "^5.8.3",
+    "vite-bundle-analyzer": "^1.3.2",
     "yargs": "^17.7.2"
   },
   "config": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import pkg from './package.json';
+import { adapter as analyzerAdapterForRollup, analyzer } from 'vite-bundle-analyzer';
 
 export default [
   {
@@ -79,6 +80,10 @@ export default [
         __DEV__: 'true',
         preventAssignment: true,
       }),
+      process.env.ANALYZE === 'true' && analyzerAdapterForRollup(analyzer({
+        analyzerMode: 'static',
+        openAnalyzer: true,
+      })),
       {
         name: 'create-cjs-index',
         buildEnd: () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7992,6 +7992,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vite-bundle-analyzer@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/vite-bundle-analyzer/-/vite-bundle-analyzer-1.3.2.tgz#087d6312c9cffcb9be5320bf1b9fb9c136c26486"
+  integrity sha512-Od4ILUKRvBV3LuO/E+S+c1XULlxdkRZPSf6Vzzu+UAXG0D3hZYUu9imZIkSj/PU4e1FB14yB+av8g3KiljH8zQ==
+
 walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"


### PR DESCRIPTION
First part of #163.

By adding an analyzer to rollup, we can see inside the bundle (unlike `size-limit --why` where we can only see the bundle as a whole, w/o insight):

<img width="1578" height="963" alt="image" src="https://github.com/user-attachments/assets/765573ad-4d8a-40c3-b82a-b49ef4e65e37" />
