### PR TITLE
refactor: separating and minifying errors via error codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/mutative.esm.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,10 @@ import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import pkg from './package.json';
-import { adapter as analyzerAdapterForRollup, analyzer } from 'vite-bundle-analyzer';
+import {
+  adapter as analyzerAdapterForRollup,
+  analyzer,
+} from 'vite-bundle-analyzer';
 
 export default [
   {
@@ -80,10 +83,13 @@ export default [
         __DEV__: 'true',
         preventAssignment: true,
       }),
-      process.env.ANALYZE === 'true' && analyzerAdapterForRollup(analyzer({
-        analyzerMode: 'static',
-        openAnalyzer: true,
-      })),
+      process.env.ANALYZE === 'true' &&
+        analyzerAdapterForRollup(
+          analyzer({
+            analyzerMode: 'static',
+            openAnalyzer: true,
+          })
+        ),
       {
         name: 'create-cjs-index',
         buildEnd: () => {

--- a/src/current.ts
+++ b/src/current.ts
@@ -12,7 +12,7 @@ import {
   set,
   shallowCopy,
 } from './utils';
-import { die } from './error';
+import { die, ErrorCode } from './error';
 
 export function handleReturnValue<T extends object>(options: {
   rootDraft: ProxyDraft<any> | undefined;
@@ -133,7 +133,7 @@ export function current<T extends object>(target: Draft<T>): T;
 export function current<T extends object>(target: T): T;
 export function current<T extends object>(target: T | Draft<T>): T {
   if (!isDraft(target)) {
-    die(7, target);
+    die(ErrorCode.CurrentOnNonDraft, target);
   }
   return getCurrent(target);
 }

--- a/src/current.ts
+++ b/src/current.ts
@@ -12,6 +12,7 @@ import {
   set,
   shallowCopy,
 } from './utils';
+import { die } from './error';
 
 export function handleReturnValue<T extends object>(options: {
   rootDraft: ProxyDraft<any> | undefined;
@@ -132,7 +133,7 @@ export function current<T extends object>(target: Draft<T>): T;
 export function current<T extends object>(target: T): T;
 export function current<T extends object>(target: T | Draft<T>): T {
   if (!isDraft(target)) {
-    throw new Error(`current() is only used for Draft, parameter: ${target}`);
+    die(7, target);
   }
   return getCurrent(target);
 }

--- a/src/draft.ts
+++ b/src/draft.ts
@@ -33,6 +33,7 @@ import {
 } from './utils';
 import { checkReadable } from './unsafe';
 import { generatePatches } from './patch';
+import { die } from './error';
 
 const proxyHandler: ProxyHandler<ProxyDraft> = {
   get(target: ProxyDraft, key: string | number | symbol, receiver: any) {
@@ -124,9 +125,7 @@ const proxyHandler: ProxyHandler<ProxyDraft> = {
   },
   set(target: ProxyDraft, key: string | number | symbol, value: any) {
     if (target.type === DraftType.Set || target.type === DraftType.Map) {
-      throw new Error(
-        `Map/Set draft does not support any property assignment.`
-      );
+      die(1);
     }
     let _key: number;
     if (
@@ -138,9 +137,7 @@ const proxyHandler: ProxyHandler<ProxyDraft> = {
         (key === 0 || _key === 0 || String(_key) === String(key))
       )
     ) {
-      throw new Error(
-        `Only supports setting array indices and the 'length' property.`
-      );
+      die(2);
     }
     const desc = getDescriptor(latest(target), key);
     if (desc?.set) {
@@ -196,10 +193,10 @@ const proxyHandler: ProxyHandler<ProxyDraft> = {
     return Reflect.getPrototypeOf(target.original);
   },
   setPrototypeOf() {
-    throw new Error(`Cannot call 'setPrototypeOf()' on drafts`);
+    die(3);
   },
   defineProperty() {
-    throw new Error(`Cannot call 'defineProperty()' on drafts`);
+    die(4);
   },
   deleteProperty(target: ProxyDraft, key: string | symbol) {
     if (target.type === DraftType.Array) {

--- a/src/draft.ts
+++ b/src/draft.ts
@@ -33,7 +33,7 @@ import {
 } from './utils';
 import { checkReadable } from './unsafe';
 import { generatePatches } from './patch';
-import { die } from './error';
+import { die, ErrorCode } from './error';
 
 const proxyHandler: ProxyHandler<ProxyDraft> = {
   get(target: ProxyDraft, key: string | number | symbol, receiver: any) {
@@ -125,7 +125,7 @@ const proxyHandler: ProxyHandler<ProxyDraft> = {
   },
   set(target: ProxyDraft, key: string | number | symbol, value: any) {
     if (target.type === DraftType.Set || target.type === DraftType.Map) {
-      die(1);
+      die(ErrorCode.CannotAssignToMapOrSet);
     }
     let _key: number;
     if (
@@ -137,7 +137,7 @@ const proxyHandler: ProxyHandler<ProxyDraft> = {
         (key === 0 || _key === 0 || String(_key) === String(key))
       )
     ) {
-      die(2);
+      die(ErrorCode.InvalidArrayIndex);
     }
     const desc = getDescriptor(latest(target), key);
     if (desc?.set) {
@@ -193,10 +193,10 @@ const proxyHandler: ProxyHandler<ProxyDraft> = {
     return Reflect.getPrototypeOf(target.original);
   },
   setPrototypeOf() {
-    die(3);
+    die(ErrorCode.CannotSetPrototypeOfDraft);
   },
   defineProperty() {
-    die(4);
+    die(ErrorCode.CannotDefinePropertyOnDraft);
   },
   deleteProperty(target: ProxyDraft, key: string | symbol) {
     if (target.type === DraftType.Array) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,30 @@
+const errors: ((...args: any[]) => string)[] = __DEV__
+  ? [
+      () =>
+        `Invalid base state: create() only supports plain objects, arrays, Set, Map or using mark() to mark the state as immutable.`,
+      () => `Map/Set draft does not support any property assignment.`,
+      () => `Only supports setting array indices and the 'length' property.`,
+      () => `Cannot call 'setPrototypeOf()' on drafts`,
+      () => `Cannot call 'defineProperty()' on drafts`,
+      () =>
+        `Either the value is returned as a new non-draft value, or only the draft is modified without returning any value.`,
+      () => `Cannot return a modified child draft.`,
+      (target) => `current() is only used for Draft, parameter: ${target}`,
+      () =>
+        `Strict mode: Mutable data cannot be accessed directly, please use 'unsafe(callback)' wrap.`,
+      (markResult) => `Unsupported mark result: ${markResult}`,
+      () =>
+        `Please check mark() to ensure that it is a stable marker draftable function.`,
+      () => `Cannot modify frozen object`,
+      (path) => `Cannot resolve patch at '${path.join('/')}'.`,
+    ]
+  : [];
+
+export function die(error: number, ...args: any[]): never {
+  if (__DEV__) {
+    throw new Error(errors[error](...args));
+  }
+  throw new Error(
+    `Minified Mutative error #${error}; visit https://mutative.js.org/docs/extra-topics/errors`
+  );
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,28 +1,91 @@
-const errors: ((...args: any[]) => string)[] = __DEV__
+/**
+ * This exported const enum relies on the program-level TypeScript compilation
+ * provided by `@rollup/plugin-typescript` to inline members across modules.
+ * Isolated TypeScript transforms, such as Babel or SWC, may emit runtime enum
+ * code instead. If the compiler changes, verify that production bundles contain
+ * neither an `ErrorCode` object nor these member names.
+ */
+export const enum ErrorCode {
+  InvalidBaseState = 0,
+  CannotAssignToMapOrSet = 1,
+  InvalidArrayIndex = 2,
+  CannotSetPrototypeOfDraft = 3,
+  CannotDefinePropertyOnDraft = 4,
+  MutateAndReturn = 5,
+  CannotReturnModifiedChildDraft = 6,
+  CurrentOnNonDraft = 7,
+  StrictModeAccess = 8,
+  UnsupportedMarkResult = 9,
+  InvalidMark = 10,
+  CannotModifyFrozenObject = 11,
+  InvalidPatchPath = 12,
+}
+
+type ErrorArguments = {
+  [ErrorCode.InvalidBaseState]: [];
+  [ErrorCode.CannotAssignToMapOrSet]: [];
+  [ErrorCode.InvalidArrayIndex]: [];
+  [ErrorCode.CannotSetPrototypeOfDraft]: [];
+  [ErrorCode.CannotDefinePropertyOnDraft]: [];
+  [ErrorCode.MutateAndReturn]: [];
+  [ErrorCode.CannotReturnModifiedChildDraft]: [];
+  [ErrorCode.CurrentOnNonDraft]: [target: any];
+  [ErrorCode.StrictModeAccess]: [];
+  [ErrorCode.UnsupportedMarkResult]: [markResult: any];
+  [ErrorCode.InvalidMark]: [];
+  [ErrorCode.CannotModifyFrozenObject]: [];
+  [ErrorCode.InvalidPatchPath]: [path: (string | number)[]];
+};
+
+type ErrorBuilders = {
+  [Code in ErrorCode]: (...args: ErrorArguments[Code]) => string;
+};
+
+const errors: ErrorBuilders = __DEV__
   ? [
+      // ErrorCode.InvalidBaseState
       () =>
         `Invalid base state: create() only supports plain objects, arrays, Set, Map or using mark() to mark the state as immutable.`,
+      // ErrorCode.CannotAssignToMapOrSet
       () => `Map/Set draft does not support any property assignment.`,
+      // ErrorCode.InvalidArrayIndex
       () => `Only supports setting array indices and the 'length' property.`,
+      // ErrorCode.CannotSetPrototypeOfDraft
       () => `Cannot call 'setPrototypeOf()' on drafts`,
+      // ErrorCode.CannotDefinePropertyOnDraft
       () => `Cannot call 'defineProperty()' on drafts`,
+      // ErrorCode.MutateAndReturn
       () =>
         `Either the value is returned as a new non-draft value, or only the draft is modified without returning any value.`,
+      // ErrorCode.CannotReturnModifiedChildDraft
       () => `Cannot return a modified child draft.`,
+      // ErrorCode.CurrentOnNonDraft
       (target) => `current() is only used for Draft, parameter: ${target}`,
+      // ErrorCode.StrictModeAccess
       () =>
         `Strict mode: Mutable data cannot be accessed directly, please use 'unsafe(callback)' wrap.`,
+      // ErrorCode.UnsupportedMarkResult
       (markResult) => `Unsupported mark result: ${markResult}`,
+      // ErrorCode.InvalidMark
       () =>
         `Please check mark() to ensure that it is a stable marker draftable function.`,
+      // ErrorCode.CannotModifyFrozenObject
       () => `Cannot modify frozen object`,
+      // ErrorCode.InvalidPatchPath
       (path) => `Cannot resolve patch at '${path.join('/')}'.`,
     ]
-  : [];
+  : ([] as unknown as ErrorBuilders);
 
-export function die(error: number, ...args: any[]): never {
+export function die<Code extends ErrorCode>(
+  error: Code,
+  ...args: ErrorArguments[Code]
+): never {
   if (__DEV__) {
-    throw new Error(errors[error](...args));
+    throw new Error(
+      (errors[error] as (...builderArgs: ErrorArguments[Code]) => string)(
+        ...args
+      )
+    );
   }
   throw new Error(
     `Minified Mutative error #${error}; visit https://mutative.js.org/docs/extra-topics/errors`

--- a/src/makeCreator.ts
+++ b/src/makeCreator.ts
@@ -17,6 +17,7 @@ import {
 } from './utils';
 import { current, handleReturnValue } from './current';
 import { RAW_RETURN_SYMBOL, dataTypes } from './constant';
+import { die } from './error';
 
 type MakeCreator = <
   _F extends boolean = false,
@@ -154,16 +155,12 @@ export const makeCreator: MakeCreator = (arg) => {
       typeof state === 'object' &&
       state !== null
     ) {
-      throw new Error(
-        `Invalid base state: create() only supports plain objects, arrays, Set, Map or using mark() to mark the state as immutable.`
-      );
+      die(0);
     }
     const [draft, finalize] = draftify(state, _options);
     if (typeof arg1 !== 'function') {
       if (!isDraftable(state, _options)) {
-        throw new Error(
-          `Invalid base state: create() only supports plain objects, arrays, Set, Map or using mark() to mark the state as immutable.`
-        );
+        die(0);
       }
       return [draft, finalize];
     }
@@ -182,9 +179,7 @@ export const makeCreator: MakeCreator = (arg) => {
           !isEqual(value, draft) &&
           proxyDraft?.operated
         ) {
-          throw new Error(
-            `Either the value is returned as a new non-draft value, or only the draft is modified without returning any value.`
-          );
+          die(5);
         }
         const rawReturnValue = value?.[RAW_RETURN_SYMBOL] as [any] | undefined;
         if (rawReturnValue) {
@@ -211,7 +206,7 @@ export const makeCreator: MakeCreator = (arg) => {
       const returnedProxyDraft = getProxyDraft(value)!;
       if (_options === returnedProxyDraft.options) {
         if (returnedProxyDraft.operated) {
-          throw new Error(`Cannot return a modified child draft.`);
+          die(6);
         }
         return finalize([current(value)]);
       }

--- a/src/makeCreator.ts
+++ b/src/makeCreator.ts
@@ -17,7 +17,7 @@ import {
 } from './utils';
 import { current, handleReturnValue } from './current';
 import { RAW_RETURN_SYMBOL, dataTypes } from './constant';
-import { die } from './error';
+import { die, ErrorCode } from './error';
 
 type MakeCreator = <
   _F extends boolean = false,
@@ -155,12 +155,12 @@ export const makeCreator: MakeCreator = (arg) => {
       typeof state === 'object' &&
       state !== null
     ) {
-      die(0);
+      die(ErrorCode.InvalidBaseState);
     }
     const [draft, finalize] = draftify(state, _options);
     if (typeof arg1 !== 'function') {
       if (!isDraftable(state, _options)) {
-        die(0);
+        die(ErrorCode.InvalidBaseState);
       }
       return [draft, finalize];
     }
@@ -179,7 +179,7 @@ export const makeCreator: MakeCreator = (arg) => {
           !isEqual(value, draft) &&
           proxyDraft?.operated
         ) {
-          die(5);
+          die(ErrorCode.MutateAndReturn);
         }
         const rawReturnValue = value?.[RAW_RETURN_SYMBOL] as [any] | undefined;
         if (rawReturnValue) {
@@ -206,7 +206,7 @@ export const makeCreator: MakeCreator = (arg) => {
       const returnedProxyDraft = getProxyDraft(value)!;
       if (_options === returnedProxyDraft.options) {
         if (returnedProxyDraft.operated) {
-          die(6);
+          die(ErrorCode.CannotReturnModifiedChildDraft);
         }
         return finalize([current(value)]);
       }

--- a/src/set.ts
+++ b/src/set.ts
@@ -15,7 +15,7 @@ const getNextIterator =
   (
     target: ProxyDraft<any>,
     iterator: IterableIterator<any>,
-    { isValuesIterator }: { isValuesIterator: boolean }
+    isValuesIterator: boolean
   ) =>
   () => {
     const result = iterator.next();
@@ -121,7 +121,7 @@ export const setHandler = {
     const iterator = target.setMap!.keys();
     return {
       [Symbol.iterator]: () => this.values(),
-      next: getNextIterator(target, iterator, { isValuesIterator: true }),
+      next: getNextIterator(target, iterator, true),
     };
   },
   entries(): IterableIterator<[any, any]> {
@@ -130,9 +130,11 @@ export const setHandler = {
     const iterator = target.setMap!.keys();
     return {
       [Symbol.iterator]: () => this.entries(),
-      next: getNextIterator(target, iterator, {
-        isValuesIterator: false,
-      }) as () => IteratorReturnResult<any>,
+      next: getNextIterator(
+        target,
+        iterator,
+        false
+      ) as () => IteratorReturnResult<any>,
     };
   },
   keys(): IterableIterator<any> {
@@ -151,36 +153,31 @@ export const setHandler = {
   },
 };
 
-if (Set.prototype.difference) {
+if ('difference' in Set.prototype) {
   // for compatibility with new Set methods
   // https://github.com/tc39/proposal-set-methods
   // And `https://github.com/tc39/proposal-set-methods/blob/main/details.md#symbolspecies` has some details about the `@@species` symbol.
   // So we can't use SubSet instance constructor to get the constructor of the SubSet instance.
-  Object.assign(setHandler, {
-    intersection(this: Set<any>, other: ReadonlySetLike<any>): Set<any> {
-      return Set.prototype.intersection.call(new Set(this.values()), other);
-    },
-    union(this: Set<any>, other: ReadonlySetLike<any>): Set<any> {
-      return Set.prototype.union.call(new Set(this.values()), other);
-    },
-    difference(this: Set<any>, other: ReadonlySetLike<any>): Set<any> {
-      return Set.prototype.difference.call(new Set(this.values()), other);
-    },
-    symmetricDifference(this: Set<any>, other: ReadonlySetLike<any>): Set<any> {
-      return Set.prototype.symmetricDifference.call(
+  (
+    [
+      'intersection',
+      'union',
+      'difference',
+      'symmetricDifference',
+      'isSubsetOf',
+      'isSupersetOf',
+      'isDisjointFrom',
+    ] as const
+  ).forEach((method) => {
+    (setHandler as any)[method] = function (
+      this: Set<any>,
+      other: ReadonlySetLike<any>
+    ) {
+      return (Set.prototype[method] as Function).call(
         new Set(this.values()),
         other
       );
-    },
-    isSubsetOf(this: Set<any>, other: ReadonlySetLike<any>): boolean {
-      return Set.prototype.isSubsetOf.call(new Set(this.values()), other);
-    },
-    isSupersetOf(this: Set<any>, other: ReadonlySetLike<any>): boolean {
-      return Set.prototype.isSupersetOf.call(new Set(this.values()), other);
-    },
-    isDisjointFrom(this: Set<any>, other: ReadonlySetLike<any>): boolean {
-      return Set.prototype.isDisjointFrom.call(new Set(this.values()), other);
-    },
+    };
   });
 }
 

--- a/src/unsafe.ts
+++ b/src/unsafe.ts
@@ -1,5 +1,6 @@
 import { Options } from './interface';
 import { isDraftable } from './utils';
+import { die } from './error';
 
 let readable = false;
 
@@ -14,9 +15,7 @@ export const checkReadable = (
     (!isDraftable(value, options) || ignoreCheckDraftable) &&
     !readable
   ) {
-    throw new Error(
-      `Strict mode: Mutable data cannot be accessed directly, please use 'unsafe(callback)' wrap.`
-    );
+    die(8);
   }
 };
 

--- a/src/unsafe.ts
+++ b/src/unsafe.ts
@@ -1,6 +1,6 @@
 import { Options } from './interface';
 import { isDraftable } from './utils';
-import { die } from './error';
+import { die, ErrorCode } from './error';
 
 let readable = false;
 
@@ -15,7 +15,7 @@ export const checkReadable = (
     (!isDraftable(value, options) || ignoreCheckDraftable) &&
     !readable
   ) {
-    die(8);
+    die(ErrorCode.StrictModeAccess);
   }
 };
 

--- a/src/utils/copy.ts
+++ b/src/utils/copy.ts
@@ -2,6 +2,7 @@ import type { Options, ProxyDraft } from '../interface';
 import { dataTypes } from '../constant';
 import { getValue, isDraft, isDraftable } from './draft';
 import { isBaseMapInstance, isBaseSetInstance } from './proto';
+import { die } from '../error';
 
 function strictCopy(target: any) {
   const copy = Object.create(Object.getPrototypeOf(target));
@@ -64,7 +65,7 @@ export function shallowCopy(original: any, options?: Options<any, any>) {
       }
       return markResult();
     }
-    throw new Error(`Unsupported mark result: ${markResult}`);
+    die(9, markResult);
   } else if (
     typeof original === 'object' &&
     Object.getPrototypeOf(original) === Object.prototype
@@ -82,9 +83,7 @@ export function shallowCopy(original: any, options?: Options<any, any>) {
     });
     return copy;
   } else {
-    throw new Error(
-      `Please check mark() to ensure that it is a stable marker draftable function.`
-    );
+    die(10);
   }
 }
 

--- a/src/utils/copy.ts
+++ b/src/utils/copy.ts
@@ -2,7 +2,7 @@ import type { Options, ProxyDraft } from '../interface';
 import { dataTypes } from '../constant';
 import { getValue, isDraft, isDraftable } from './draft';
 import { isBaseMapInstance, isBaseSetInstance } from './proto';
-import { die } from '../error';
+import { die, ErrorCode } from '../error';
 
 function strictCopy(target: any) {
   const copy = Object.create(Object.getPrototypeOf(target));
@@ -65,7 +65,7 @@ export function shallowCopy(original: any, options?: Options<any, any>) {
       }
       return markResult();
     }
-    die(9, markResult);
+    die(ErrorCode.UnsupportedMarkResult, markResult);
   } else if (
     typeof original === 'object' &&
     Object.getPrototypeOf(original) === Object.prototype
@@ -83,7 +83,7 @@ export function shallowCopy(original: any, options?: Options<any, any>) {
     });
     return copy;
   } else {
-    die(10);
+    die(ErrorCode.InvalidMark);
   }
 }
 

--- a/src/utils/deepFreeze.ts
+++ b/src/utils/deepFreeze.ts
@@ -1,8 +1,9 @@
 import { DraftType } from '../interface';
 import { getType, isDraft } from './draft';
+import { die } from '../error';
 
 function throwFrozenError() {
-  throw new Error('Cannot modify frozen object');
+  die(11);
 }
 
 function isFreezable(value: any) {

--- a/src/utils/deepFreeze.ts
+++ b/src/utils/deepFreeze.ts
@@ -1,9 +1,9 @@
 import { DraftType } from '../interface';
 import { getType, isDraft } from './draft';
-import { die } from '../error';
+import { die, ErrorCode } from '../error';
 
 function throwFrozenError() {
-  die(11);
+  die(ErrorCode.CannotModifyFrozenObject);
 }
 
 function isFreezable(value: any) {

--- a/src/utils/draft.ts
+++ b/src/utils/draft.ts
@@ -1,6 +1,7 @@
 import { DraftType, Mark, ProxyDraft } from '../interface';
 import { dataTypes, PROXY_DRAFT } from '../constant';
 import { has } from './proto';
+import { die } from '../error';
 
 export function latest<T = any>(proxyDraft: ProxyDraft): T {
   return proxyDraft.copy ?? proxyDraft.original;
@@ -146,7 +147,7 @@ export function resolvePath(base: any, path: (string | number)[]) {
     // use `index` in Set draft
     base = get(getType(base) === DraftType.Set ? Array.from(base) : base, key);
     if (typeof base !== 'object') {
-      throw new Error(`Cannot resolve patch at '${path.join('/')}'.`);
+      die(12, path);
     }
   }
   return base;

--- a/src/utils/draft.ts
+++ b/src/utils/draft.ts
@@ -1,7 +1,7 @@
 import { DraftType, Mark, ProxyDraft } from '../interface';
 import { dataTypes, PROXY_DRAFT } from '../constant';
 import { has } from './proto';
-import { die } from '../error';
+import { die, ErrorCode } from '../error';
 
 export function latest<T = any>(proxyDraft: ProxyDraft): T {
   return proxyDraft.copy ?? proxyDraft.original;
@@ -147,7 +147,7 @@ export function resolvePath(base: any, path: (string | number)[]) {
     // use `index` in Set draft
     base = get(getType(base) === DraftType.Set ? Array.from(base) : base, key);
     if (typeof base !== 'object') {
-      die(12, path);
+      die(ErrorCode.InvalidPatchPath, path);
     }
   }
   return base;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
-  "include": ["src", "types", "global.d.ts"],
+  "include": ["src", "types"],
   "compilerOptions": {
     "target": "ES2015",
     "module": "esnext",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
-  "include": ["src", "types"],
+  "include": ["src", "types", "global.d.ts"],
   "compilerOptions": {
     "target": "ES2015",
     "module": "esnext",

--- a/website/docs/extra-topics/errors.md
+++ b/website/docs/extra-topics/errors.md
@@ -1,0 +1,22 @@
+---
+title: Production error codes
+---
+
+Mutative removes full error messages from production bundles. Use the code in
+the production error to find the original message below.
+
+| Code | Development error                                                                                             |
+| ---: | ------------------------------------------------------------------------------------------------------------- |
+|    0 | Invalid base state: `create()` only supports plain objects, arrays, Set, Map, or a state marked as immutable. |
+|    1 | Map/Set drafts do not support property assignment.                                                            |
+|    2 | Arrays only support assigning indices and the `length` property.                                              |
+|    3 | `setPrototypeOf()` cannot be called on drafts.                                                                |
+|    4 | `defineProperty()` cannot be called on drafts.                                                                |
+|    5 | A producer cannot both return a new non-draft value and modify its draft.                                     |
+|    6 | A modified child draft cannot be returned.                                                                    |
+|    7 | `current()` only accepts a draft.                                                                             |
+|    8 | Mutable data cannot be accessed directly in strict mode; wrap access in `unsafe(callback)`.                   |
+|    9 | The configured `mark()` function returned an unsupported value.                                               |
+|   10 | The configured `mark()` function is not a stable marker function.                                             |
+|   11 | A frozen object cannot be modified.                                                                           |
+|   12 | A patch path could not be resolved.                                                                           |

--- a/website/docs/extra-topics/errors.md
+++ b/website/docs/extra-topics/errors.md
@@ -1,9 +1,19 @@
 ---
 title: Production error codes
+description: Decode minified Mutative production errors and find their full development messages.
 ---
 
-Mutative removes full error messages from production bundles. Use the code in
-the production error to find the original message below.
+In Mutative's minified production build, full error messages are replaced with
+numeric codes to reduce the number of bytes sent to users.
+
+When debugging locally, we recommend using the development build. It retains
+the full error messages, additional validation, and warnings that provide more
+context about potential problems in your application.
+
+If an exception occurs in production, its message includes an error code and a
+link to this page. Find that code in the table below to recover the full
+development message. The source identifier is provided for contributors
+working on Mutative itself.
 
 | Code | Source identifier                | Development error                                                                                             |
 | ---: | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |

--- a/website/docs/extra-topics/errors.md
+++ b/website/docs/extra-topics/errors.md
@@ -5,18 +5,18 @@ title: Production error codes
 Mutative removes full error messages from production bundles. Use the code in
 the production error to find the original message below.
 
-| Code | Development error                                                                                             |
-| ---: | ------------------------------------------------------------------------------------------------------------- |
-|    0 | Invalid base state: `create()` only supports plain objects, arrays, Set, Map, or a state marked as immutable. |
-|    1 | Map/Set drafts do not support property assignment.                                                            |
-|    2 | Arrays only support assigning indices and the `length` property.                                              |
-|    3 | `setPrototypeOf()` cannot be called on drafts.                                                                |
-|    4 | `defineProperty()` cannot be called on drafts.                                                                |
-|    5 | A producer cannot both return a new non-draft value and modify its draft.                                     |
-|    6 | A modified child draft cannot be returned.                                                                    |
-|    7 | `current()` only accepts a draft.                                                                             |
-|    8 | Mutable data cannot be accessed directly in strict mode; wrap access in `unsafe(callback)`.                   |
-|    9 | The configured `mark()` function returned an unsupported value.                                               |
-|   10 | The configured `mark()` function is not a stable marker function.                                             |
-|   11 | A frozen object cannot be modified.                                                                           |
-|   12 | A patch path could not be resolved.                                                                           |
+| Code | Source identifier                | Development error                                                                                             |
+| ---: | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+|    0 | `InvalidBaseState`               | Invalid base state: `create()` only supports plain objects, arrays, Set, Map, or a state marked as immutable. |
+|    1 | `CannotAssignToMapOrSet`         | Map/Set drafts do not support property assignment.                                                            |
+|    2 | `InvalidArrayIndex`              | Arrays only support assigning indices and the `length` property.                                              |
+|    3 | `CannotSetPrototypeOfDraft`      | `setPrototypeOf()` cannot be called on drafts.                                                                |
+|    4 | `CannotDefinePropertyOnDraft`    | `defineProperty()` cannot be called on drafts.                                                                |
+|    5 | `MutateAndReturn`                | A producer cannot both return a new non-draft value and modify its draft.                                     |
+|    6 | `CannotReturnModifiedChildDraft` | A modified child draft cannot be returned.                                                                    |
+|    7 | `CurrentOnNonDraft`              | `current()` only accepts a draft.                                                                             |
+|    8 | `StrictModeAccess`               | Mutable data cannot be accessed directly in strict mode; wrap access in `unsafe(callback)`.                   |
+|    9 | `UnsupportedMarkResult`          | The configured `mark()` function returned an unsupported value.                                               |
+|   10 | `InvalidMark`                    | The configured `mark()` function is not a stable marker function.                                             |
+|   11 | `CannotModifyFrozenObject`       | A frozen object cannot be modified.                                                                           |
+|   12 | `InvalidPatchPath`               | A patch path could not be resolved.                                                                           |


### PR DESCRIPTION
Parts of #163 

By adding "Minified Error Codes", I am able to reduce the production build's size from the current 6.66 KiB gzip to approximately 5.64 KiB gzip, which is a 15% reduction.

We are now actually smaller than a full-featured `immer + use-immer` setup:

```ts
export { enableMapSet, enablePatches } from "immer";
export { useImmer } from "use-immer";

// 5.98 KiB after gzipped
```

https://bundlejs.com/?config=%7B%22analysis%22%3Atrue%2C%22esbuild%22%3A%7B%22external%22%3A%5B%22react%22%5D%7D%7D

However, immer doesn't enable patches by default (while mutative always includes patches by default), thus, for a non-patches-included setup, immer still has the advantage, but we are close.